### PR TITLE
general improvements to the Automake build system

### DIFF
--- a/Source/Makefile.am
+++ b/Source/Makefile.am
@@ -1,4 +1,83 @@
-bin_PROGRAMS = winmbf
-winmbf_SOURCES = am_map.c d_deh.c d_items.c d_main.c d_net.c doomdef.c doomstat.c dstrings.c f_finale.c f_wipe.c g_game.c hu_lib.c hu_stuff.c i_main.c i_net.c info.c i_sound.c i_stretch.c i_system.c i_video.c m_argv.c m_bbox.c m_cheat.c m_menu.c m_misc.c mmus2mid.c m_random.c p_ceilng.c p_doors.c p_enemy.c p_floor.c p_genlin.c p_inter.c p_lights.c p_map.c p_maputl.c p_mobj.c p_plats.c p_pspr.c p_saveg.c p_setup.c p_sight.c p_spec.c p_switch.c p_telept.c p_tick.c p_user.c r_bsp.c r_data.c r_draw.c r_main.c r_plane.c r_segs.c r_sky.c r_things.c sounds.c s_sound.c st_lib.c st_stuff.c tables.c version.c v_video.c wi_stuff.c w_wad.c z_zone.c
-winmbf_CFLAGS = @SDL_CFLAGS@ @SDL_mixer_CFLAGS@ @SDL_net_CFLAGS@
-winmbf_LDADD = @SDL_LIBS@ @SDL_mixer_LIBS@ @SDL_net_LIBS@
+bin_PROGRAMS = @PACKAGE_NAME@
+@PACKAGE_NAME@_SOURCES = \
+	am_map.c   am_map.h \
+	d_deh.c    d_deh.h \
+	d_englsh.h \
+	d_event.h \
+	d_french.h \
+	d_io.h \
+	d_items.c  d_items.h \
+	d_main.c   d_main.h \
+	d_net.c    d_net.h \
+	d_player.h \
+	d_textur.h \
+	d_think.h \
+	d_ticcmd.h \
+	doomdata.h \
+	doomdef.c  doomdef.h \
+	doomstat.c doomstat.h \
+	doomtype.h \
+	dstrings.c dstrings.h \
+	f_finale.c f_finale.h \
+	f_wipe.c   f_wipe.h \
+	g_game.c   g_game.h \
+	hu_lib.c   hu_lib.h \
+	hu_stuff.c hu_stuff.h \
+	i_main.c \
+	i_net.c    i_net.h \
+	i_sound.c  i_sound.h \
+	i_stretch.c \
+	i_system.c i_system.h \
+	i_video.c  i_video.h \
+	info.c     info.h \
+	m_argv.c   m_argv.h \
+	m_bbox.c   m_bbox.h \
+	m_cheat.c  m_cheat.h \
+	m_fixed.h \
+	m_menu.c   m_menu.h \
+	m_misc.c   m_misc.h \
+	m_random.c m_random.h \
+	m_swap.h \
+	mmus2mid.c mmus2mid.h \
+	p_ceilng.c \
+	p_doors.c \
+	p_enemy.c  p_enemy.h \
+	p_floor.c \
+	p_genlin.c \
+	p_inter.c  p_inter.h \
+	p_lights.c \
+	p_map.c    p_map.h \
+	p_maputl.c p_maputl.h \
+	p_mobj.c   p_mobj.h \
+	p_plats.c \
+	p_pspr.c   p_pspr.h \
+	p_saveg.c  p_saveg.h \
+	p_setup.c  p_setup.h \
+	p_sight.c \
+	p_spec.c   p_spec.h \
+	p_switch.c \
+	p_telept.c \
+	p_tick.c   p_tick.h \
+	p_user.c   p_user.h \
+	r_bsp.c    r_bsp.h \
+	r_data.c   r_data.h \
+	r_defs.h \
+	r_draw.c   r_draw.h \
+	r_main.c   r_main.h \
+	r_plane.c  r_plane.h \
+	r_segs.c   r_segs.h \
+	r_sky.c    r_sky.h \
+	r_state.h \
+	r_things.c r_things.h \
+	s_sound.c  s_sound.h \
+	sounds.c   sounds.h \
+	st_lib.c   st_lib.h \
+	st_stuff.c st_stuff.h \
+	tables.c   tables.h \
+	v_video.c  v_video.h \
+	version.c  version.h \
+	w_wad.c    w_wad.h \
+	wi_stuff.c wi_stuff.h \
+	z_zone.c   z_zone.h
+@PACKAGE_NAME@_CFLAGS = @SDL_CFLAGS@ @SDL_mixer_CFLAGS@ @SDL_net_CFLAGS@
+@PACKAGE_NAME@_LDADD = @SDL_LIBS@ @SDL_mixer_LIBS@ @SDL_net_LIBS@

--- a/Source/doomtype.h
+++ b/Source/doomtype.h
@@ -30,6 +30,10 @@
 #ifndef __DOOMTYPE__
 #define __DOOMTYPE__
 
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
 #ifndef __BYTEBOOL__
 #define __BYTEBOOL__
 // Fixed to use builtin bool type with C++.

--- a/Source/info.h
+++ b/Source/info.h
@@ -31,6 +31,10 @@
 #ifndef __INFO__
 #define __INFO__
 
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
 // Needed for action function pointer handling.
 #include "d_think.h"
 

--- a/Source/sounds.h
+++ b/Source/sounds.h
@@ -30,6 +30,10 @@
 #ifndef __SOUNDS__
 #define __SOUNDS__
 
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
 //
 // SoundFX struct.
 //

--- a/configure.ac
+++ b/configure.ac
@@ -5,7 +5,7 @@ AC_PREREQ([2.69])
 AC_INIT([winmbf], [2.03])
 AM_INIT_AUTOMAKE([foreign no-define])
 AC_CONFIG_SRCDIR([Source/version.c])
-#AC_CONFIG_HEADERS([config.h])
+AC_CONFIG_HEADERS([config.h])
 
 # Checks for programs.
 AC_PROG_CC
@@ -15,7 +15,7 @@ AC_SEARCH_LIBS([pow], [m])
 PKG_CHECK_MODULES([SDL],       [sdl])
 PKG_CHECK_MODULES([SDL_mixer], [SDL_mixer])
 PKG_CHECK_MODULES([SDL_net],   [SDL_net])
-AC_DEFINE([MY_SDL_VER])
+AC_DEFINE([MY_SDL_VER], [1], [This is WinMBF])
 
 # Checks for header files.
 AC_CHECK_HEADERS([fcntl.h limits.h malloc.h stddef.h stdlib.h string.h unistd.h])
@@ -35,10 +35,10 @@ AC_FUNC_REALLOC
 AC_CHECK_FUNCS([atexit memmove memset mkdir pow putenv strcasecmp strchr strdup strerror strncasecmp strrchr strstr strtol])
 
 AC_ARG_ENABLE([dogs], AS_HELP_STRING([--disable-dogs], [Disable support for helper dogs]))
-AS_IF([test "x$enable_dogs" != "xno"], [AC_DEFINE([DOGS])])
+AS_IF([test "x$enable_dogs" != "xno"], [AC_DEFINE([DOGS], [1], [Support for helper dogs])])
 
 AC_ARG_ENABLE([beta], AS_HELP_STRING([--disable-beta], [Disable support for beta emulation]))
-AS_IF([test "x$enable_beta" != "xno"], [AC_DEFINE([BETA])])
+AS_IF([test "x$enable_beta" != "xno"], [AC_DEFINE([BETA], [1], [Support for beta emulation])])
 
 AC_CONFIG_FILES([Makefile Source/Makefile])
 AC_OUTPUT

--- a/configure.ac
+++ b/configure.ac
@@ -34,5 +34,11 @@ AC_FUNC_MALLOC
 AC_FUNC_REALLOC
 AC_CHECK_FUNCS([atexit memmove memset mkdir pow putenv strcasecmp strchr strdup strerror strncasecmp strrchr strstr strtol])
 
+AC_ARG_ENABLE([dogs], AS_HELP_STRING([--disable-dogs], [Disable support for helper dogs]))
+AS_IF([test "x$enable_dogs" != "xno"], [AC_DEFINE([DOGS])])
+
+AC_ARG_ENABLE([beta], AS_HELP_STRING([--disable-beta], [Disable support for beta emulation]))
+AS_IF([test "x$enable_beta" != "xno"], [AC_DEFINE([BETA])])
+
 AC_CONFIG_FILES([Makefile Source/Makefile])
 AC_OUTPUT


### PR DESCRIPTION
 * Call the binary by the package name.
 * Add header files to sources.
 * Optionally build with support for helper dogs and beta emulation
   (enabled by default).
 * Build with config.h instead of passing all defines on the command line.